### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/ghostibles0927/32a9574a-2245-44e2-9049-15166ce69696/9b14d90f-8962-4599-bb73-dc50c72e3cd9/_apis/work/boardbadge/b895f456-a2cc-4668-8c36-a06a9566b868)](https://dev.azure.com/ghostibles0927/32a9574a-2245-44e2-9049-15166ce69696/_boards/board/t/9b14d90f-8962-4599-bb73-dc50c72e3cd9/Microsoft.RequirementCategory)
 # dotnetdemo
 The boilerplate dotnet demo.  Not very interesting


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#241](https://dev.azure.com/ghostibles0927/32a9574a-2245-44e2-9049-15166ce69696/_workitems/edit/241). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.